### PR TITLE
Source maps with `sb-babel-cli`

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,8 +28,8 @@ Options:
   -w, --watch                         Watch files for changes
   --ignored <list>                    Ignored files and directories that match the given globs
   --write-flow-sources                Write .flow files that are symlinked to source files. Helps 
+                                      with monorepos in some cases
   --source-maps                       Outputs source maps (Node 12+)
-  with monorepos in some cases
   --disable-cache                     Force recompile all files ignoring cache
   --keep-extra-files                  Do NOT delete extra files in the output directory
   -o, --output-directory <directory>  Output directory to write transpiled files to

--- a/README.md
+++ b/README.md
@@ -27,7 +27,9 @@ Options:
   -V, --version                       output the version number
   -w, --watch                         Watch files for changes
   --ignored <list>                    Ignored files and directories that match the given globs
-  --write-flow-sources                Write .flow files that are symlinked to source files. Helps with monorepos in some cases
+  --write-flow-sources                Write .flow files that are symlinked to source files. Helps 
+  --source-maps                       Outputs source maps (Node 12+)
+  with monorepos in some cases
   --disable-cache                     Force recompile all files ignoring cache
   --keep-extra-files                  Do NOT delete extra files in the output directory
   -o, --output-directory <directory>  Output directory to write transpiled files to

--- a/src/cli/index.js
+++ b/src/cli/index.js
@@ -24,6 +24,10 @@ program
     '--write-flow-sources',
     'Write .flow files that are symlinked to source files. Helps with monorepos in some cases',
   )
+  .option(
+    '--source-maps',
+    'Write .map files so that code can be executed and original source filenames and line numbers can be used',
+  )
   .option('--disable-cache', 'Force recompile all files ignoring cache')
   .option('--keep-extra-files', 'Do NOT delete extra files in the output directory')
   .option('-o, --output-directory <directory>', 'Output directory to write transpiled files to')
@@ -83,6 +87,7 @@ const config = {
   disableCache: get(program, 'disableCache', false),
   writeFlowSources: get(program, 'writeFlowSources', false),
   keepExtraFiles: get(program, 'keepExtraFiles', false),
+  sourceMaps: get(program, 'sourceMaps', false),
   sourceDirectory: program.args[0],
   outputDirectory: program.outputDirectory,
   typescript: program.typescript,

--- a/src/cli/index.js
+++ b/src/cli/index.js
@@ -25,7 +25,7 @@ program
     'Write .flow files that are symlinked to source files. Helps with monorepos in some cases',
   )
   .option(
-    '--source-maps',
+    '--source-maps <option>',
     'Write .map files so that code can be executed and original source filenames and line numbers can be used',
   )
   .option('--disable-cache', 'Force recompile all files ignoring cache')

--- a/src/helpers.js
+++ b/src/helpers.js
@@ -14,6 +14,7 @@ export const SUPPORTED_FLAGS = [
   '--inspect',
   '--inspect-brk',
   '--inspect-publish-uid',
+  '--enable-source-maps',
 ]
 export class CLIError extends Error {}
 

--- a/src/index.js
+++ b/src/index.js
@@ -42,7 +42,7 @@ async function main(config) {
 
     const transformed = await babelTransformFile(sourceFile, {
       root: config.root,
-      sourceMaps: config.sourceMaps,
+      sourceMaps: config.sourceMaps === 'inline' ? 'inline' : Boolean(config.sourceMaps),
     })
     await makeDir(path.dirname(outputFile))
 
@@ -51,7 +51,7 @@ async function main(config) {
     await Promise.all([
       fs.writeFile(
         outputFile,
-        config.sourceMaps
+        config.sourceMaps && config.sourceMaps !== 'inline'
           ? `${transformed.code}\n\n//# sourceMappingURL=${path.basename(mapFile)}`
           : transformed.code,
         {

--- a/src/index.js
+++ b/src/index.js
@@ -46,7 +46,7 @@ async function main(config) {
     })
     await makeDir(path.dirname(outputFile))
 
-    const mapFile = `${outputFile}.js.map`
+    const mapFile = `${outputFile}.map`
 
     await Promise.all([
       fs.writeFile(

--- a/src/index.js
+++ b/src/index.js
@@ -46,7 +46,7 @@ async function main(config) {
     })
     await makeDir(path.dirname(outputFile))
 
-    const mapFile = outputFile.replace(/\..*$/, '.js.map')
+    const mapFile = `${outputFile}.js.map`
 
     await Promise.all([
       fs.writeFile(

--- a/src/index.js
+++ b/src/index.js
@@ -59,7 +59,9 @@ async function main(config) {
         },
       ),
       // Write source maps if option is given.
-      config.sourceMaps ? fs.writeFile(mapFile, JSON.stringify(transformed.map)) : null,
+      config.sourceMaps && config.sourceMaps !== 'inline'
+        ? fs.writeFile(mapFile, JSON.stringify(transformed.map))
+        : null,
     ])
     log(sourceFile, '->', outputFile)
     if (config.writeFlowSources) {
@@ -115,7 +117,10 @@ async function main(config) {
     outputDirectory: config.outputDirectory,
     ignored: config.ignored,
     keepExtraFiles: config.keepExtraFiles,
-    filesToKeep: input => input.concat(config.writeFlowSources ? input.map(i => `${i}.flow`) : []),
+    filesToKeep: input =>
+      input
+        .concat(config.writeFlowSources ? input.map(i => `${i}.flow`) : [])
+        .concat(config.sourceMaps ? input.map(i => `${i}.map`) : []),
     async callback(sourceFile, outputFile, stats) {
       const cachedTimestamp = await timestampCache.get(getSha1(sourceFile)).value()
       if (cachedTimestamp === stats.mtime.getTime()) {


### PR DESCRIPTION
This PR adds support for generating and utilizing Node 12+ core source map support to show real file names and line numbers with `sb-babel-cli`.

![image](https://user-images.githubusercontent.com/516498/94819781-a79a0500-03cd-11eb-84d1-5a439058500c.png)

**^^ .ts source files and line numbers in stack traces**